### PR TITLE
Sugerencias de mejoras a la pauta de las Ofertas Laborales

### DIFF
--- a/OfertasLaborales.md
+++ b/OfertasLaborales.md
@@ -9,7 +9,7 @@ En Español :
 >**Beneficios**:                                                                                                                
 >**Tipo de Contrato**: ( Fulltime - Partime - Freelance )                                                                       
 >**Remuneración Aproximada**: ( Min - Max - Aprox )                                                                             
->**Correo Electronico**: ( Para Adjuntar CV )                                                                                   
+>**Correo Electrónico**: ( Para Adjuntar CV )                                                                                   
 
 In English : 
 >**Company Name**:                                                                                                      
@@ -19,4 +19,8 @@ In English :
 >**Benefits**:                                                                                                                
 >**Type of Contract**: ( Fulltime - Partime - Freelance )                                                                       
 >**Approximate remuneration**: ( Min - Max - Aprox )                                                                             
->**E-mail**: ( to attach cv )          
+>**E-mail**: ( to attach cv )
+
+Observaciones:
+> * Si la remuneración estimada es acorde a la experiencia, especificar un monto por cada rango de experiencia esperada.
+> * Si las postulaciones se deben hacer por una plataforma web, se puede omitir el campo de Correo Electrónico, especificando en su lugar una url con la oferta laboral.


### PR DESCRIPTION
Viendo las distintas ofertas laborales a través del tiempo, me he dado cuenta de que generalmente se generan algunos problemas. Por ejemplo, mucha gente usa la pauta, pero en remuneración pone "Según experiencia". Es bueno dejar especificado que si la remuneración es acorde a experiencia, se debe poner la experiencia y los montos aproximados por cada rango de experiencia (ej: Junior, semi-senior, senior).

Otro problema que puede ocurrir, es que ciertas empresas utilizan plataformas de postulación, por lo que el campo de correo electrónico es innecesario. Hacerlo opcional para poner en su lugar una url al sitio web con la oferta arregla este problema.

La idea es discutir estos cambios, y si se pueden mejorar, mejor para todos.

pd: También arreglé una falta ortográfica.